### PR TITLE
Changed API version for autoscaling

### DIFF
--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -91,13 +91,13 @@ spec:
   domains:
     - easyrent-api-prod.cit362.com
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: easyrent-api-prod-autoscaler
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: apps/v2beta2
     kind: Deployment
     name: easyrent-api-prod-autoscaler
   minReplicas: 1


### PR DESCRIPTION
We can either use v2beta2 like this or move back to v1, delete the metrics: section and utilize targetCPUUtilizationPercentage: 80 instead. I feel that v2beta2 has more options to choose from i.e. average CPU utilization versus instant CPU utilization as we see in v1. Keep in mind that v2beta2 is in beta and may produce problems in the future.